### PR TITLE
Pdf converter

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,11 +97,12 @@ func main() {
 						continue
 					}
 				}else{
+					formattedUrl := url
 					if *format {
-						*url = format_url(*url, *timezone)
+						*formattedUrl = format_url(*url, *timezone)
 						debug("PDF URL: ", *url)
 					}
-					pdf_img(*url, *output)
+					pdf_img(*formattedUrl, *output)
 				}
 				
 			} else {

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 	timezone := flag.String("timezone", "America/Chicago", "override timezone (tzinfo format)")
 	xpath := flag.String("xpath", "", "xpath to <img> tag in url")
 	test := flag.Bool("test", false, "disable wait-online and cooldown")
+	convPdf := flag.Bool("pdf", false, "convert pdf to image")
 	mode := flag.String("mode", "fill", "image scaling mode (fill, center)")
 	scale := flag.Float64("scale", 1, "scale image prior to centering")
 	// top := flag.Int("top", 0, "crop from top")
@@ -36,21 +37,30 @@ func main() {
 	var err error
 
 	// download/rescale image, then quit
-	if *test {
-		// use a built-in image source
-		if *source != "" {
-			img, err = sources[*source](*timezone)
+	if *test {	
+		if *convPdf {
+			//probably needs a bit of a refactor but this is the first time ive ever used go
+			if *format {
+				*url = format_url(*url, *timezone)
+				debug("PDF URL: ", *url)
+			}
+			pdf_img(*url, *output)
 		} else {
-			img, err = custom(*url, *format, *timezone, *xpath)
-		}
+			// use a built-in image source
+			if *source != "" {
+				img, err = sources[*source](*timezone)
+			} else {
+				img, err = custom(*url, *format, *timezone, *xpath)
+			}
 
-		if err != nil {
-			panic(err)
+			if err != nil {
+				panic(err)
+			}
+			img = adjust(img, *mode, *scale)
+			imaging.Save(img, *output)
+			debug("Image saved to ", *output)
 		}
-		// img = adjust(img, *top, *left, *right, *bottom)
-		img = adjust(img, *mode, *scale)
-		imaging.Save(img, *output)
-		debug("Image saved to ", *output)
+		
 	} else {
 		// initialize with zero date
 		time_last_success := time.Time{};
@@ -70,27 +80,34 @@ func main() {
 			// make sure we don't hammer server every time wifi is turned on
 			if time.Now().Sub(time_last_success).Seconds() > float64(*cooldown) {
 
-				if *source != "" {
-					img, err = sources[*source](*timezone)
-				} else {
-					img, err = custom(*url, *format, *timezone, *xpath)
+				if(!*convPdf){
+					if *source != "" {
+						img, err = sources[*source](*timezone)
+					} else {
+						img, err = custom(*url, *format, *timezone, *xpath)
+					}
+	
+					if err == nil {
+						time_last_success = time.Now()
+						img = adjust(img, *mode, *scale)
+						imaging.Save(img, *output)
+						debug("Image saved to ", *output)
+					} else {
+						fmt.Println(err)
+						continue
+					}
+				}else{
+					if *format {
+						*url = format_url(*url, *timezone)
+						debug("PDF URL: ", *url)
+					}
+					pdf_img(*url, *output)
 				}
-
-				if err == nil {
-					time_last_success = time.Now()
-				} else {
-					fmt.Println(err)
-					continue
-				}
+				
 			} else {
 				debug("Hit cooldown limit")
 				continue
 			}
-
-			// img = adjust(img, *top, *left, *right, *bottom)
-			img = adjust(img, *mode, *scale)
-			imaging.Save(img, *output)
-			debug("Image saved to ", *output)
 		}
 	}
 }

--- a/pdftool.go
+++ b/pdftool.go
@@ -1,0 +1,39 @@
+package main
+
+import(
+    "fmt"
+    "os"
+    "os/exec"
+    "strings"
+)
+
+func pdf_img(url string, output string) {
+    os.Setenv("PATH", "/opt/bin")
+    magickExecutable, _ := exec.LookPath("convert")
+    debug("Coverting pdf ", url)
+
+    builder := strings.Builder{}
+    builder.WriteString("png:")
+    builder.WriteString(output)
+    outpng := builder.String();
+
+    cmd := &exec.Cmd {
+        Path: magickExecutable,
+        Args: []string{ magickExecutable, 
+            "-density", "226", 
+            url, 
+            "-resize","1404",
+            "-colorspace", "gray",
+            "-gravity", "north",
+            "-crop", "1404x1872+0+100",
+            "+repage",
+            outpng,
+        },
+        Stdout: os.Stdout,
+        Stderr: os.Stdout,
+    }
+
+    if err := cmd.Run(); err != nil {
+        fmt.Println("Error:", err)
+    }
+}

--- a/services/nyt-pdf.service
+++ b/services/nyt-pdf.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=New York Times PDF
+
+[Service]
+ExecStart=/home/root/renews.arm \
+    -output /usr/share/remarkable/suspended.png \
+    -verbose \
+    -timezone TZ \
+    -cooldown COOLDOWN \
+    -url https://cdn.newseum.org/dfp/pdf%%d/NY_NYT.pdf \
+    -pdf \
+    -strftime \
+    -mode fill
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hey @Evidlo . Did some mucking about this afternoon. Noticed that a bunch of the images on newseum.org are pretty low resolution. Made a really, really dirty change to enable downloading/resizing of pdfs from the same source. I've never written anything in go before, so go easy on me..

In order to use it, the remarkable needs to have imagemagick and ghostscript installed. I got these off entware, which i noticed you also maintain for the remarkable. The cropping could really be optimized (especially at the top), or possibly using `trim` on imagemagick would do this magically for most of the pdfs on newseum, at-least.. 