### PR TITLE
feat: remarkable paper-pro compatible version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ renews.arm:
 	go get ./...
 	env GOOS=linux GOARCH=arm GOARM=7 go build -o renews.arm
 
+renews.arm64:
+	go get ./...
+	env GOOS=linux GOARCH=arm64 go build -o renews.arm64
+
 renews.x86:
 	go get ./...
 	go build -o renews.x86
@@ -23,8 +27,8 @@ download_prebuilt:
 
 # build release
 .PHONY: release
-release: renews.arm renews.x86
-	zip release.zip renews.arm renews.x86
+release: renews.arm renews.x86 renews.arm64
+	zip release.zip renews.arm renews.x86 renews.arm64
 	gh release create --latest --verify-tag $(version) release.zip
 
 # tag and push tag
@@ -34,7 +38,7 @@ tag:
 	git push --tags
 
 clean:
-	rm -f renews.x86 renews.arm release.zip
+	rm -f renews.x86 renews.arm renews.arm64 release.zip
 
 # define install
 # 	# make sure ssh agent is running

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ renews.arm:
 
 renews.arm64:
 	go get ./...
-	env GOOS=linux GOARCH=arm64 go build -o renews.arm64
+	env GOOS=linux GOARCH=arm64 go build -tags "rmpp" -o renews.arm64
 
 renews.x86:
 	go get ./...

--- a/screen.go
+++ b/screen.go
@@ -1,0 +1,8 @@
+//go:build !rmpp
+// +build !rmpp
+
+package main
+
+func GetScreenSize() (int, int) {
+	return 1404, 1872
+}

--- a/screen_rmpp.go
+++ b/screen_rmpp.go
@@ -1,0 +1,8 @@
+//go:build rmpp
+// +build rmpp
+
+package main
+
+func GetScreenSize() (int, int) {
+	return 1620, 2160
+}

--- a/sources.go
+++ b/sources.go
@@ -119,8 +119,7 @@ func adjust(img image.Image, mode string, scale float64) image.Image {
 
 	debug("Adjusting image")
 
-	re_width := 1620
-	re_height := 2160
+	re_width, re_height := GetScreenSize()
 
 	if mode == "fill" {
 		// scale image to remarkable width

--- a/sources.go
+++ b/sources.go
@@ -119,8 +119,8 @@ func adjust(img image.Image, mode string, scale float64) image.Image {
 
 	debug("Adjusting image")
 
-	re_width := 1404
-	re_height := 1872
+	re_width := 1620
+	re_height := 2160
 
 	if mode == "fill" {
 		// scale image to remarkable width


### PR DESCRIPTION
Here is the static build to go along with this

[renews.arm64.zip](https://github.com/user-attachments/files/17269469/renews.arm64.zip)

I think maybe I need to use go build tags to improve it further and allow the width and height to be per arch target. There might even be a way to use custom tags to override the device width and height, which on the paper-pro (which this is for) is `1620 x 2160` instead of `1404 x 1872`.