### PR TITLE
fix: xkcd random comic

### DIFF
--- a/services/xkcd.service
+++ b/services/xkcd.service
@@ -6,7 +6,7 @@ ExecStart=/home/root/bin/renews.arm \
     -output /usr/share/remarkable/suspended.png \
     -verbose \
     -cooldown COOLDOWN \
-    -url https://xkcd.com \
+    -url https://c.xkcd.com/random/comic/ \
     -xpath '//div[@id="comic"]/img/@src' \
     -xpath-title '//div[@id="comic"]/img/@alt' \
     -xpath-subtitle '//div[@id="comic"]/img/@title' \


### PR DESCRIPTION
This adjusts the xkcd to use their current random xkcd url (taken from their site and the "Random" button.

I've tested it and instead of getting some numenor joke over and over and over. I now get a new comic every time I run or this updates. I think that (and your script) are pretty cool.